### PR TITLE
Finalise DMGenerationChestEvent

### DIFF
--- a/src/com/timvisee/DungeonMaze/event/generation/DMGenerationChestEvent.java
+++ b/src/com/timvisee/DungeonMaze/event/generation/DMGenerationChestEvent.java
@@ -1,9 +1,11 @@
 package com.timvisee.DungeonMaze.event.generation;
 
 import java.util.List;
+import java.util.Random;
 
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
 import org.bukkit.inventory.ItemStack;
 
 import com.timvisee.DungeonMaze.event.EventHandler.DMEventHandler;
@@ -12,10 +14,12 @@ public class DMGenerationChestEvent extends DMEventHandler {
 	
 	private Block b;
 	private List<ItemStack> is;
+	private Random random;
 	
-	public DMGenerationChestEvent(Block b, List<ItemStack> is) {
+	public DMGenerationChestEvent(Block b, Random random, List<ItemStack> is) {
 		this.b = b;
 		this.is = is;
+		this.random = random;
 	}
 	
 	public Block getBlock() {
@@ -24,6 +28,10 @@ public class DMGenerationChestEvent extends DMEventHandler {
 	
 	public List<ItemStack> getContents() {
 		return this.is;
+	}
+	
+	public Random getRandom() {
+		return this.random;
 	}
 	
 	public void setContents(List<ItemStack> is) {
@@ -35,4 +43,12 @@ public class DMGenerationChestEvent extends DMEventHandler {
 		return this.b.getWorld();
 	}
 
+	public void addItemsToChest(Random random, Chest chest, List<ItemStack> newContents) {
+		// Add new content to a chest
+		chest.getInventory().clear();
+		for (int i = 0; i < newContents.size(); i++) {
+			chest.getInventory().setItem(random.nextInt(chest.getInventory().getSize()), newContents.get(i));
+		}
+		chest.update();
+	}
 }

--- a/src/com/timvisee/DungeonMaze/populator/ChestPopulator.java
+++ b/src/com/timvisee/DungeonMaze/populator/ChestPopulator.java
@@ -9,7 +9,6 @@ import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
-import org.bukkit.event.Event;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.inventory.ItemStack;
 
@@ -59,22 +58,42 @@ public class ChestPopulator extends BlockPopulator {
 										
 										// Generate new inventory contents
 										List<ItemStack> contents = generateChestContents(random);
-										
+										chestBlock.setTypeId(54);
 										// Call the chest generation event
-										DMGenerationChestEvent event = new DMGenerationChestEvent(chestBlock, contents);
+										DMGenerationChestEvent event = new DMGenerationChestEvent(chestBlock, random, contents);
 										//DungeonMaze.getServer().getPluginManager().callEvent(event);
 										//plugin.getDMEventHandler().callEvent(event);
 										Bukkit.getServer().getPluginManager().callEvent(event);
 										
 										// Do the event
 										if(!event.isCancelled()) {
-											// Set the block to a chest
-											chestBlock.setTypeId(54);
 											
 											// Add the contents to the chest
-											addItemsToChest(random, (Chest) chestBlock.getState(), event.getContents());
+											event.addItemsToChest(random, (Chest) chestBlock.getState(), event.getContents());
 										} else {
-											// The event has been cancelled, do nothing
+											// do nothing
+										}
+									}
+									else if (chestBlock.getTypeId() == 54 ) {
+										// The follow is for rare case when the chest is generate before the plugin does the event
+										Chest chest = (Chest) chestBlock.getState();
+										if (chest.getInventory() != null) {
+											// Generate new inventory contents
+											List<ItemStack> contents = generateChestContents(random);
+										
+											// Call the chest generation event
+											DMGenerationChestEvent event = new DMGenerationChestEvent(chestBlock, random, contents);
+											//DungeonMaze.getServer().getPluginManager().callEvent(event);
+											//plugin.getDMEventHandler().callEvent(event);
+											Bukkit.getServer().getPluginManager().callEvent(event);
+										
+											// Do the event
+											if(!event.isCancelled()) {	
+												// Add the contents to the chest
+												event.addItemsToChest(random, (Chest) chestBlock.getState(), event.getContents());
+											} else {
+												// do nothing
+											}
 										}
 									}
 								}
@@ -259,14 +278,5 @@ public class ChestPopulator extends BlockPopulator {
 			newContents.add(items.get(random.nextInt(items.size())));
 		}
 		return newContents;
-	}
-	
-	public void addItemsToChest(Random random, Chest chest, List<ItemStack> newContents) {
-		// Add new content to a chest
-		chest.getInventory().clear();
-		for (int i = 0; i < newContents.size(); i++) {
-			chest.getInventory().setItem(random.nextInt(chest.getInventory().getSize()), newContents.get(i));
-		}
-		chest.update();
 	}
 }


### PR DESCRIPTION
Tested with this little plugin :
https://dl.dropbox.com/u/60299638/ChestDiamond.jar

This plugin from me ,change all of Generate Chest content to a single Diamond
(that's an example)

here is the source from my listener :

``` java
@EventHandler (priority = EventPriority.NORMAL)
public void onChestGenerate (DMGenerationChestEvent event) {
event.setCancelled(true);
Random random = event.getRandom();
Chest chest = (Chest) event.getBlock().getState();
List<ItemStack> itemStack = event.getContents();
itemStack.clear();
itemStack.add(new ItemStack(Material.DIAMOND, 1));
event.addItemsToChest(random, chest, itemStack);
}
```

Xephi
